### PR TITLE
 Contents' permissions and Scheduled Searches WebHook copying 

### DIFF
--- a/modules/content_tab.py
+++ b/modules/content_tab.py
@@ -638,8 +638,6 @@ class content_tab(QtWidgets.QWidget):
 
         source_user_id_to_dest_user_id = {}
         for userId, email in source_user_id_to_email.items():
-            email = str(email).replace('teads.tv', 'teads.com')
-            email = str(email).replace('security+sumosupport+teadstv@sumologic.com', 'security+sumosupport+teads-1@sumologic.com')
             if email in des_user_email_to_id.keys():
                 source_user_id_to_dest_user_id[userId] = des_user_email_to_id[email]
             else:
@@ -678,8 +676,6 @@ class content_tab(QtWidgets.QWidget):
         requestResults = {}
         for sourceContentId, sourceContentPath in source_ids_to_paths.items():
             logger.info("The current source content id={} and path={}".format(sourceContentId, sourceContentPath))
-            sourceContentPath = str(sourceContentPath).replace('teads.tv', 'teads.com')
-            sourceContentPath = str(sourceContentPath).replace('security+sumosupport+teadstv@sumologic.com', 'security+sumosupport+teads-1@sumologic.com')
             if sourceContentPath in dest_paths_to_ids.keys():
                 logger.info('Key found')
                 destContentId = dest_paths_to_ids[sourceContentPath]

--- a/modules/content_tab.py
+++ b/modules/content_tab.py
@@ -704,7 +704,6 @@ class content_tab(QtWidgets.QWidget):
         
         return requestResults
 
-
     def update_content_webhookid(self, fromsumo, tosumo, content):
         source_connections = fromsumo.get_connections_sync()
         dest_connections = tosumo.get_connections_sync()

--- a/modules/content_tab.py
+++ b/modules/content_tab.py
@@ -957,8 +957,6 @@ If you are absolutely sure, type "DELETE" in the box below.
                     item = QtWidgets.QListWidgetItem(self.icons['Folder'], item_name)
                 elif object['itemType'] == 'Search':
                     item = QtWidgets.QListWidgetItem(self.icons['Search'], item_name)
-                elif object['itemType'] == 'Search':
-                    item = QtWidgets.QListWidgetItem(self.icons['scheduledsearch'], item_name)
                 elif object['itemType'] == 'Dashboard' or object['itemType'] == 'Report':
                     item = QtWidgets.QListWidgetItem(self.icons['Dashboard'], item_name)
                 elif object['itemType'] == 'Lookups':

--- a/modules/content_tab.py
+++ b/modules/content_tab.py
@@ -587,18 +587,15 @@ class content_tab(QtWidgets.QWidget):
         try:
             selecteditems = ContentListWidgetFrom.selectedItems()
             if len(selecteditems) > 0:  # make sure something was selected
-                logger.info("[Content] Copying Content - if len(selecteditems) > 0")
                 fromsumo = SumoLogic(fromid, fromkey, endpoint=fromurl, log_level=self.mainwindow.log_level)
                 tosumo = SumoLogic(toid, tokey, endpoint=tourl, log_level=self.mainwindow.log_level)
                 currentdir = ContentListWidgetTo.currentdirlist[-1]
                 tofolderid = ContentListWidgetTo.currentcontent['id']
-
                 for selecteditem in selecteditems:
-                    dest_webhookId = ''
-                    item_id = selecteditem.details['id']
-                    content = fromsumo.export_content_job_sync(item_id, adminmode=fromadminmode)
-                    content = self.update_content_webhookid(fromsumo, tosumo, content)  
-                    status = tosumo.import_content_job_sync(tofolderid, content, adminmode=toadminmode)
+                        item_id = selecteditem.details['id']
+                        content = fromsumo.export_content_job_sync(item_id, adminmode=fromadminmode)
+                        content = self.update_content_webhookid(fromsumo, tosumo, content)
+                        status = tosumo.import_content_job_sync(tofolderid, content, adminmode=toadminmode)
                 self.updatecontentlist(ContentListWidgetTo, tourl, toid, tokey, toradioselected, todirectorylabel)
                 return
 

--- a/modules/content_tab.py
+++ b/modules/content_tab.py
@@ -591,23 +591,22 @@ class content_tab(QtWidgets.QWidget):
                 tosumo = SumoLogic(toid, tokey, endpoint=tourl, log_level=self.mainwindow.log_level)
                 currentdir = ContentListWidgetTo.currentdirlist[-1]
                 tofolderid = ContentListWidgetTo.currentcontent['id']
-                # toBasePath = tosumo.get_item_path(tofolderid, adminmode=toadminmode)['path']
 
                 for selecteditem in selecteditems:
                         item_id = selecteditem.details['id']
-                        # fromBasePath = fromsumo.get_item_path(item_id, adminmode=fromadminmode)['path']
                         item_type = selecteditem.details['itemType']
 
                         if item_type == 'Folder':
                             fromFolder = fromsumo.get_folder(item_id, adminmode=fromadminmode)
-                            folders = contents_to_itemsPaths(logger, fromsumo, fromFolder, adminmode=fromadminmode)
-                            logger.info(folders)
+                            fromPermissions = contents_to_itemsPaths(logger, fromsumo, fromFolder, adminmode=fromadminmode)
+                        
                         content = fromsumo.export_content_job_sync(item_id, adminmode=fromadminmode)
                         content = self.update_content_webhookid(fromsumo, tosumo, content)
                         status = tosumo.import_content_job_sync(tofolderid, content, adminmode=toadminmode)
 
-                        # toPaths = contents_to_itemsPaths(tosumo, content,toBasePath, adminmode=toadminmode)
-                        # self.get_source_to_dest_content_id_lookup(fromsumo, tosumo, fromPaths, toPaths)
+                toFolder = tosumo.get_folder(tofolderid, adminmode=toadminmode)
+                toPermissions = contents_to_itemsPaths(logger, tosumo, toFolder, isTopLevel=True, adminmode=toadminmode)
+                logger.info(toPermissions)
                 self.updatecontentlist(ContentListWidgetTo, tourl, toid, tokey, toradioselected, todirectorylabel)
                 return
 
@@ -620,11 +619,11 @@ class content_tab(QtWidgets.QWidget):
             self.mainwindow.errorbox('Something went wrong:\n\n' + str(e))
         return
 
-    # def get_source_to_dest_content_id_lookup(self, fromsumo, tosumo, fromPaths, toPaths, fromadminmode,toadminmode):
-    #         source_contents_path_id = {fromsumo.get_content_by_path(path, adminmode=fromadminmode)['id']:path for path in fromPaths}
-    #         dest_contents_path_id = {tosumo.get_content_by_path(path, toadminmode=toadminmode)['id']:path for path in toPaths}
-    #         logger.info(source_contents_path_id)
-    #         logger.info(dest_contents_path_id)
+    def get_source_to_dest_content_id_lookup(self, fromsumo, tosumo, fromPaths, toPaths, fromadminmode,toadminmode):
+            source_contents_path_id = {fromsumo.get_content_by_path(path, adminmode=fromadminmode)['id']:path for path in fromPaths}
+            dest_contents_path_id = {tosumo.get_content_by_path(path, toadminmode=toadminmode)['id']:path for path in toPaths}
+            logger.info(source_contents_path_id)
+            logger.info(dest_contents_path_id)
 
 
     def update_content_webhookid(self, fromsumo, tosumo, content):

--- a/modules/content_tab.py
+++ b/modules/content_tab.py
@@ -703,11 +703,7 @@ class content_tab(QtWidgets.QWidget):
                 logger.warn("Failed to import content {} from {} to {}, Source content id:{}".format(sourceContentPath,fromBasePath, toBasePath, sourceContentId))
         
         return requestResults
-        
 
-        
-
-        
 
     def update_content_webhookid(self, fromsumo, tosumo, content):
         source_connections = fromsumo.get_connections_sync()

--- a/modules/content_tab.py
+++ b/modules/content_tab.py
@@ -591,6 +591,37 @@ class content_tab(QtWidgets.QWidget):
                 tosumo = SumoLogic(toid, tokey, endpoint=tourl, log_level=self.mainwindow.log_level)
                 currentdir = ContentListWidgetTo.currentdirlist[-1]
                 tofolderid = ContentListWidgetTo.currentcontent['id']
+                fromUsers = fromsumo.get_users_sync()
+                toUsers = tosumo.get_users_sync()
+                fromRoles = fromsumo.get_roles_sync()
+                toRoles = tosumo.get_roles_sync()
+                source_org_id = fromsumo.get_org_id()
+                dest_org_id = tosumo.get_org_id()
+
+                source_user_id_to_email = {user['id']:str(user['email']).replace('teads.tv', 'teads.com') for user in fromUsers}
+                des_user_email_to_id = {user['email']:user['id'] for user in toUsers}
+
+                source_user_id_to_dest_user_id = {}
+                for userId, email in source_user_id_to_email.items():
+                    if email in des_user_email_to_id.keys():
+                        source_user_id_to_dest_user_id[userId] = des_user_email_to_id[email]
+                    else:
+                        logger.info("Failed to find user with e-mail: {} on the destination".format(email))
+
+                source_role_id_to_name = {role['id']:role['name'] for role in fromRoles}
+                des_role_name_to_id = {role['name']:role['id'] for role in toRoles}
+
+                source_role_id_to_dest_role_id = {}
+                for roleId, roleName in source_role_id_to_name.items():
+                    if roleName in des_role_name_to_id.keys():
+                        source_role_id_to_dest_role_id[roleId] = des_role_name_to_id[roleName]
+                    else:
+                        logger.info("Failed to find role with name: {} on the destination".format(roleName))
+
+                logger.info(source_user_id_to_dest_user_id)
+                logger.info(source_role_id_to_dest_role_id)
+                logger.info(source_org_id)
+                logger.info(dest_org_id)
 
                 for selecteditem in selecteditems:
                         item_id = selecteditem.details['id']
@@ -635,7 +666,12 @@ class content_tab(QtWidgets.QWidget):
             if sourceContentPath in dest_paths_to_ids.keys():
                 source_ids_to_dest_ids[sourceContentId] = dest_paths_to_ids[sourceContentPath] 
             else:
-                logger.warn("Failed to import content with path: {} for source source content with id {}".format(sourceContentPath, sourceContentId))
+                sourceContentPath = str(sourceContentPath).replace('teads.tv', 'teads.com')
+                sourceContentPath = str(sourceContentPath).replace('security+sumosupport+teadstv@sumologic.com', 'security+sumosupport+teads-1@sumologic.com')
+                if sourceContentPath in dest_paths_to_ids.keys():
+                    source_ids_to_dest_ids[sourceContentId] = dest_paths_to_ids[sourceContentPath]
+                else:
+                    logger.warn("Failed to import content with path: {} for source source content with id {}".format(sourceContentPath, sourceContentId))
         return source_ids_to_dest_ids
 
 

--- a/modules/content_tab.py
+++ b/modules/content_tab.py
@@ -8,7 +8,7 @@ import pathlib
 import json
 from logzero import logger
 from modules.sumologic import SumoLogic
-from modules.shared import ShowTextDialog, find_replace_specific_key_and_value
+from modules.shared import ShowTextDialog, find_replace_specific_key_and_value, contents_to_itemsPaths
 
 
 class findReplaceCopyDialog(QtWidgets.QDialog):
@@ -593,8 +593,11 @@ class content_tab(QtWidgets.QWidget):
                 tofolderid = ContentListWidgetTo.currentcontent['id']
                 for selecteditem in selecteditems:
                         item_id = selecteditem.details['id']
+                        basePath = fromsumo.get_item_path(item_id)['path']
                         content = fromsumo.export_content_job_sync(item_id, adminmode=fromadminmode)
                         content = self.update_content_webhookid(fromsumo, tosumo, content)
+                        paths = contents_to_itemsPaths(content,basePath)
+                        logger.info(paths)
                         status = tosumo.import_content_job_sync(tofolderid, content, adminmode=toadminmode)
                 self.updatecontentlist(ContentListWidgetTo, tourl, toid, tokey, toradioselected, todirectorylabel)
                 return

--- a/modules/content_tab.py
+++ b/modules/content_tab.py
@@ -591,17 +591,23 @@ class content_tab(QtWidgets.QWidget):
                 tosumo = SumoLogic(toid, tokey, endpoint=tourl, log_level=self.mainwindow.log_level)
                 currentdir = ContentListWidgetTo.currentdirlist[-1]
                 tofolderid = ContentListWidgetTo.currentcontent['id']
-                toBasePath = tosumo.get_item_path(tofolderid, adminmode=toadminmode)['path']
+                # toBasePath = tosumo.get_item_path(tofolderid, adminmode=toadminmode)['path']
 
                 for selecteditem in selecteditems:
                         item_id = selecteditem.details['id']
-                        fromBasePath = fromsumo.get_item_path(item_id, adminmode=fromadminmode)['path']
+                        # fromBasePath = fromsumo.get_item_path(item_id, adminmode=fromadminmode)['path']
+                        item_type = selecteditem.details['itemType']
+
+                        if item_type == 'Folder':
+                            fromFolder = fromsumo.get_folder(item_id, adminmode=fromadminmode)
+                            folders = contents_to_itemsPaths(logger, fromsumo, fromFolder, adminmode=fromadminmode)
+                            logger.info(folders)
                         content = fromsumo.export_content_job_sync(item_id, adminmode=fromadminmode)
                         content = self.update_content_webhookid(fromsumo, tosumo, content)
                         status = tosumo.import_content_job_sync(tofolderid, content, adminmode=toadminmode)
-                        fromPaths = contents_to_itemsPaths(content,fromBasePath)
-                        toPaths = contents_to_itemsPaths(content,toBasePath)
-                        self.get_source_to_dest_content_id_lookup(fromsumo, tosumo, fromPaths, toPaths)
+
+                        # toPaths = contents_to_itemsPaths(tosumo, content,toBasePath, adminmode=toadminmode)
+                        # self.get_source_to_dest_content_id_lookup(fromsumo, tosumo, fromPaths, toPaths)
                 self.updatecontentlist(ContentListWidgetTo, tourl, toid, tokey, toradioselected, todirectorylabel)
                 return
 
@@ -614,11 +620,11 @@ class content_tab(QtWidgets.QWidget):
             self.mainwindow.errorbox('Something went wrong:\n\n' + str(e))
         return
 
-    def get_source_to_dest_content_id_lookup(self, fromsumo, tosumo, fromPaths, toPaths):
-            source_contents_path_id = {fromsumo.get_content_by_path(path)['id']:path for path in fromPaths}
-            dest_contents_path_id = {tosumo.get_content_by_path(path)['id']:path for path in toPaths}
-            logger.info(source_contents_path_id)
-            logger.info(dest_contents_path_id)
+    # def get_source_to_dest_content_id_lookup(self, fromsumo, tosumo, fromPaths, toPaths, fromadminmode,toadminmode):
+    #         source_contents_path_id = {fromsumo.get_content_by_path(path, adminmode=fromadminmode)['id']:path for path in fromPaths}
+    #         dest_contents_path_id = {tosumo.get_content_by_path(path, toadminmode=toadminmode)['id']:path for path in toPaths}
+    #         logger.info(source_contents_path_id)
+    #         logger.info(dest_contents_path_id)
 
 
     def update_content_webhookid(self, fromsumo, tosumo, content):

--- a/modules/content_tab.py
+++ b/modules/content_tab.py
@@ -7,7 +7,6 @@ import re
 import pathlib
 import json
 import copy
-import pprint
 from logzero import logger
 from modules.sumologic import SumoLogic
 from modules.shared import ShowTextDialog, find_replace_specific_key_and_value, content_item_to_path
@@ -593,9 +592,10 @@ class content_tab(QtWidgets.QWidget):
                 tosumo = SumoLogic(toid, tokey, endpoint=tourl, log_level=self.mainwindow.log_level)
                 currentSourceDir = ContentListWidgetFrom.currentdirlist[-1]
                 fromFolderId = ContentListWidgetFrom.currentcontent['id']
+
                 currentDestDir = ContentListWidgetTo.currentdirlist[-1]
                 toFolderId = ContentListWidgetTo.currentcontent['id']
-                pprint.pprint("The Destination Folder ID=:{}\n".format(toFolderId))
+                
                 fromPaths = []
 
                 for selecteditem in selecteditems:
@@ -611,7 +611,7 @@ class content_tab(QtWidgets.QWidget):
 
                 toFolder = tosumo.get_folder(toFolderId, adminmode=toadminmode)
                 toPaths = content_item_to_path(tosumo, toFolder, adminmode=toadminmode)
-                logger.info(self.sync_copied_contents_permissions(fromsumo, tosumo, fromFolderId, toFolderId, fromPaths, toPaths, fromAdminMode=fromadminmode, toAdminMode=toadminmode))
+                self.sync_copied_contents_permissions(fromsumo, tosumo, fromFolderId, toFolderId, fromPaths, toPaths, fromAdminMode=fromadminmode, toAdminMode=toadminmode)
                 self.updatecontentlist(ContentListWidgetTo, tourl, toid, tokey, toradioselected, todirectorylabel)
                 return
 
@@ -625,7 +625,7 @@ class content_tab(QtWidgets.QWidget):
         return
 
     def get_source_to_dest_meta_ids(self, fromsumo, tosumo):
-        logger.info('Getting Source <-> Destination Meta IDs')
+        logger.info('[Content] Getting Source To Destination Meta IDs')
         source_to_dest_ids = {}
 
         fromUsers = fromsumo.get_users_sync()

--- a/modules/content_tab.py
+++ b/modules/content_tab.py
@@ -857,8 +857,6 @@ If you are absolutely sure, type "DELETE" in the box below.
                     item = QtWidgets.QListWidgetItem(self.icons['Folder'], item_name)
                 elif object['itemType'] == 'Search':
                     item = QtWidgets.QListWidgetItem(self.icons['Search'], item_name)
-                elif object['itemType'] == 'Search':
-                    item = QtWidgets.QListWidgetItem(self.icons['scheduledsearch'], item_name)
                 elif object['itemType'] == 'Dashboard' or object['itemType'] == 'Report':
                     item = QtWidgets.QListWidgetItem(self.icons['Dashboard'], item_name)
                 elif object['itemType'] == 'Lookups':

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -182,8 +182,8 @@ def import_saml_config(saml_export, sumo):
     status = sumo.create_saml_config(saml_export)
 
 def contents_to_itemsPaths(content, basePath='',paths=[]):
-    if isinstance(content, dict):
-        if 'type' in content and content['type'] in ('FolderSyncDefinition', 'SavedSearchWithScheduleSyncDefinition','DashboardSyncDefinition','DashboardV2SyncDefinition'):
+    if isinstance(content, dict) and 'name' in content and 'type' in content:
+        if content['type'] in ('FolderSyncDefinition', 'SavedSearchWithScheduleSyncDefinition','DashboardSyncDefinition','DashboardV2SyncDefinition'):
             for k, v in content.items():
                 if k == 'name':
                         basePath = (basePath + '/' + v) if basePath else ('/' + v)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -181,26 +181,29 @@ def import_saml_config(saml_export, sumo):
     # End Hacky stuff
     status = sumo.create_saml_config(saml_export)
 
-def contents_to_itemsPaths(logger, sumo, content, adminmode=False):
+def contents_to_itemsPaths(logger, sumo, content, basePath='', isTopLevel=False, adminmode=False):
     folders = []
+    currentPath = basePath
     if isinstance(content, dict):
         if 'id' in content and 'name' in content and 'itemType' in content:
-            id = content['id']
-            name = content['name']
-            itemType = content['itemType']
-            permissions = sumo.get_permissions(id,adminmode=adminmode)
-            details = {'id': id, 'name': name, 'itemType': itemType, 'permissions': permissions}
-            folders.append(details)
-            logger.info(details)
+            if not isTopLevel:
+                id = content['id']
+                name = content['name']
+                itemType = content['itemType']
+                currentPath = currentPath + '/' + name
+                permissions = sumo.get_permissions(id,adminmode=adminmode)
+                details = {'id': id, 'name': name, 'itemType': itemType, 'path': currentPath,'permissions': permissions}
+                folders.append(details)
+                logger.info(details)
 
             if 'children' in content and len(content['children']) > 0:
                 for child in content['children']:
                     if child['itemType'] == 'Folder':
                         child = sumo.get_folder(child['id'], adminmode=adminmode)
-                    folders.append(contents_to_itemsPaths(logger, sumo, child, adminmode=adminmode))
+                    folders.append(contents_to_itemsPaths(logger, sumo, child, basePath=currentPath, adminmode=adminmode))
     elif isinstance(content, list):
         for index, item in enumerate(content):
-            folders.append(contents_to_itemsPaths(logger, sumo,item, adminmode=adminmode))
+            folders.append(contents_to_itemsPaths(logger, sumo,item, basePath=basePath, adminmode=adminmode))
 
     return folders
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -204,6 +204,30 @@ def content_item_to_path(sumo, content, adminmode=False):
 
     return paths
 
+def CopyUsersAndAssignedRoles(user_id, fromsumo, tosumo):       
+    user = fromsumo.get_user_and_roles(user_id)
+    dest_roles = tosumo.get_roles_sync()
+    for source_role in user['roles']:
+        role_already_exists_in_dest = False
+        source_role_id = source_role['id']
+        for dest_role in dest_roles:
+            if dest_role['name'] == source_role['name']:
+                role_already_exists_in_dest = True
+                dest_role_id = dest_role['id']
+        if role_already_exists_in_dest:
+            user['roleIds'].append(dest_role_id)
+            user['roleIds'].remove(source_role_id)
+        else:
+            source_role['users'] = []
+            tosumo.create_role(source_role)
+            updated_dest_roles = tosumo.get_roles_sync()
+            for updated_dest_role in updated_dest_roles:
+                if updated_dest_role['name'] == source_role['name']:
+                    user['roleIds'].append(updated_dest_role['id'])
+            user['roleIds'].remove(source_role_id)
+    
+    return tosumo.create_user(user['firstName'], user['lastName'], email, user['roleIds'])
+
 
 
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -181,29 +181,28 @@ def import_saml_config(saml_export, sumo):
     # End Hacky stuff
     status = sumo.create_saml_config(saml_export)
 
-def content_item_to_permissions(sumo, content, isTopLevel=False, adminmode=False):
-    folders = []
+def content_item_to_path(sumo, content, adminmode=False):
+    paths = []
     if isinstance(content, dict):
         if 'id' in content and 'name' in content and 'itemType' in content:
             id = content['id']
             name = content['name']
             itemType = content['itemType']
-            permissions = sumo.get_permissions(id,explicit_only=True,adminmode=adminmode)
             currentPath = sumo.get_item_path(id, adminmode=adminmode)['path']
-            details = {'id': id, 'name': name, 'itemType': itemType, 'path': currentPath,'permissions': permissions['explicitPermissions']}
-            folders.append(details)
+            details = {'id': id, 'name': name, 'itemType': itemType, 'path': currentPath}
+            paths.append(details)
 
             if itemType == 'Folder' and 'children' in content and len(content['children']) > 0:
                 for child in content['children']:
                     if child['itemType'] == 'Folder':
                         child = sumo.get_folder(child['id'], adminmode=adminmode)
-                    folders = folders + content_item_to_permissions(sumo, child, adminmode=adminmode)
+                    paths = paths + content_item_to_path(sumo, child, adminmode=adminmode)
 
     elif isinstance(content, list):
         for index, item in enumerate(content):
-            folders = folders + content_item_to_permissions(sumo,item, adminmode=adminmode)
+            paths = paths + content_item_to_path(sumo,item, adminmode=adminmode)
 
-    return folders
+    return paths
 
 
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -181,19 +181,15 @@ def import_saml_config(saml_export, sumo):
     # End Hacky stuff
     status = sumo.create_saml_config(saml_export)
 
-def content_item_to_permissions(sumo, content, basePath='', isTopLevel=False, adminmode=False):
+def content_item_to_permissions(sumo, content, isTopLevel=False, adminmode=False):
     folders = []
-    currentPath = basePath
     if isinstance(content, dict):
         if 'id' in content and 'name' in content and 'itemType' in content:
             id = content['id']
             name = content['name']
             itemType = content['itemType']
             permissions = sumo.get_permissions(id,explicit_only=True,adminmode=adminmode)
-
-            if not isTopLevel:
-                currentPath = currentPath + '/' + name
-
+            currentPath = sumo.get_item_path(id, adminmode=adminmode)['path']
             details = {'id': id, 'name': name, 'itemType': itemType, 'path': currentPath,'permissions': permissions['explicitPermissions']}
             folders.append(details)
 
@@ -201,10 +197,11 @@ def content_item_to_permissions(sumo, content, basePath='', isTopLevel=False, ad
                 for child in content['children']:
                     if child['itemType'] == 'Folder':
                         child = sumo.get_folder(child['id'], adminmode=adminmode)
-                    folders = folders + content_item_to_permissions(sumo, child, basePath=currentPath, adminmode=adminmode)
+                    folders = folders + content_item_to_permissions(sumo, child, adminmode=adminmode)
+
     elif isinstance(content, list):
         for index, item in enumerate(content):
-            folders = folders + content_item_to_permissions(sumo,item, basePath=basePath, adminmode=adminmode)
+            folders = folders + content_item_to_permissions(sumo,item, adminmode=adminmode)
 
     return folders
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -181,6 +181,21 @@ def import_saml_config(saml_export, sumo):
     # End Hacky stuff
     status = sumo.create_saml_config(saml_export)
 
+def contents_to_itemsPaths(content, basePath='',paths=[]):
+    if isinstance(content, dict):
+        if 'type' in content and content['type'] in ('FolderSyncDefinition', 'SavedSearchWithScheduleSyncDefinition','DashboardSyncDefinition','DashboardV2SyncDefinition'):
+            for k, v in content.items():
+                if k == 'name':
+                        basePath = (basePath + '/' + v) if basePath else ('/' + v)
+                        paths.append(basePath)
+                elif isinstance(v, (dict,list)):
+                    contents_to_itemsPaths(v, basePath,paths)
+
+    elif isinstance(content, list):
+        for index, item in enumerate(content):
+            contents_to_itemsPaths(item, basePath,paths)
+    return paths
+
 
 
 

--- a/modules/sumologic.py
+++ b/modules/sumologic.py
@@ -999,3 +999,15 @@ class SumoLogic(object):
         r = self.post('/v1/saml/lockdown/disable')
         return r.json()
 
+
+    # Account Contract APIs
+    def get_account_contract(self):
+        r = self.get('/v1/account/contract')
+        return r.json()
+
+    def get_org_id(self):
+        r = self.get_account_contract()
+        return r['orgId']
+
+
+

--- a/modules/sumologic.py
+++ b/modules/sumologic.py
@@ -485,12 +485,15 @@ class SumoLogic(object):
     # Content API
 
 
-    def get_content_by_path(self, item_path):
-        r= self.get('/v2/content' + str(item_path))  #path should start with /Library or something else?
+    def get_content_by_path(self, item_path, adminmode=False):
+        headers = {'isAdminMode': str(adminmode)}
+        params = {'path': item_path}
+        r= self.get('/v2/content', headers=headers, params=params)  #path should start with /Library or something else?
         return r.json()
 
-    def get_item_path(self, item_id):
-        r = self.get('/v2/content/' + str(item_id) + '/path')
+    def get_item_path(self, item_id, adminmode=False):
+        headers = {'isAdminMode': str(adminmode)}
+        r = self.get('/v2/content/' + str(item_id) + '/path', headers=headers)
         return r.json()
 
     def delete_content_job(self, item_id, adminmode=False):

--- a/modules/users_and_roles_tab.py
+++ b/modules/users_and_roles_tab.py
@@ -8,7 +8,7 @@ import pathlib
 import json
 from logzero import logger
 from modules.sumologic import SumoLogic
-from modules.shared import ShowTextDialog
+from modules.shared import ShowTextDialog, CopyUsersAndAssignedRoles
 
 
 class users_and_roles_tab(QtWidgets.QWidget):
@@ -320,27 +320,7 @@ class users_and_roles_tab(QtWidgets.QWidget):
                 tosumo = SumoLogic(toid, tokey, endpoint=tourl, log_level=self.mainwindow.log_level)
                 for selecteditem in selecteditems:
                     user_id = selecteditem.details['id']
-                    user = fromsumo.get_user_and_roles(user_id)
-                    dest_roles = tosumo.get_roles_sync()
-                    for source_role in user['roles']:
-                        role_already_exists_in_dest = False
-                        source_role_id = source_role['id']
-                        for dest_role in dest_roles:
-                            if dest_role['name'] == source_role['name']:
-                                role_already_exists_in_dest = True
-                                dest_role_id = dest_role['id']
-                        if role_already_exists_in_dest:
-                            user['roleIds'].append(dest_role_id)
-                            user['roleIds'].remove(source_role_id)
-                        else:
-                            source_role['users'] = []
-                            tosumo.create_role(source_role)
-                            updated_dest_roles = tosumo.get_roles_sync()
-                            for updated_dest_role in updated_dest_roles:
-                                if updated_dest_role['name'] == source_role['name']:
-                                    user['roleIds'].append(updated_dest_role['id'])
-                            user['roleIds'].remove(source_role_id)
-                    tosumo.create_user(user['firstName'], user['lastName'], user['email'], user['roleIds'])
+                    CopyUsersAndAssignedRoles(user_id, fromsumo, tosumo)
 
                 self.update_users_and_roles_lists(UserListWidgetTo, RoleListWidgetTo, tourl, toid, tokey)
                 return
@@ -354,7 +334,7 @@ class users_and_roles_tab(QtWidgets.QWidget):
             self.mainwindow.errorbox('Something went wrong:' + str(e))
             self.update_users_and_roles_lists(UserListWidgetTo, RoleListWidgetTo, tourl, toid, tokey)
         return
-    
+
     def backup_user(self, UserListWidget, url, id, key):
         logger.info("[Users and Roles]Backing Up User(s)")
         selecteditems = UserListWidget.selectedItems()

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ Recommended Method of Getting and Running Sumotoolbox, download the binaries
 The easiest way to download and use this tool is to download the latest binary release from the "releases"
 section of this page. 
 
-https://github.com/SumoLogic/sumologictoolbox
+https://github.com/SumoLogic/sumologictoolbox/releases
 
 Updating the Binaries
 =====================
@@ -54,7 +54,7 @@ The steps are as follows:
  
     5. Clone this repo using the following command:
     
-        git clone https://github.com/voltaire321/sumologictoolbox.git
+        git clone https://github.com/SumoLogic/sumologictoolbox.git
     
     This will create a new folder called sumotoolbox. 
     
@@ -72,7 +72,7 @@ Updating the Source
 
 When it's time to upgrade to a new version of sumotoolbox cd into the sumotoolbox directory and type:
     
-    1. git pull https://github.com/voltaire321/sumologictoolbox.git
+    1. git pull https://github.com/SumoLogic/sumologictoolbox.git
     
     2. pipenv install
     

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ Recommended Method of Getting and Running Sumotoolbox, download the binaries
 The easiest way to download and use this tool is to download the latest binary release from the "releases"
 section of this page. 
 
-http://github.com/voltaire321/sumologictoolbox/releases
+https://github.com/SumoLogic/sumologictoolbox
 
 Updating the Binaries
 =====================

--- a/readme.md
+++ b/readme.md
@@ -464,15 +464,15 @@ Credential Database:
 Screen Shots:
 =============
 
-![Collector Source Copy](https://github.com/voltaire321/sumologictoolbox/blob/master/screenshots/sumotoolbox_collector_example.png "Source Copy")
+![Collector Source Copy](https://github.com/SumoLogic/sumologictoolbox/blob/master/screenshots/sumotoolbox_collector_example.png "Source Copy")
 
-![Search API Example](https://github.com/voltaire321/sumologictoolbox/blob/master/screenshots/sumotoolbox_search_example.png "Search API")
+![Search API Example](https://github.com/SumoLogic/sumologictoolbox/sumologictoolbox/blob/master/screenshots/sumotoolbox_search_example.png "Search API")
 
-![Content API Example](https://github.com/voltaire321/sumologictoolbox/blob/master/screenshots/sumotoolbox_content_example.png "Content API")
+![Content API Example](https://github.com/SumoLogic/sumologictoolbox/sumologictoolbox/blob/master/screenshots/sumotoolbox_content_example.png "Content API")
 
-![Field Extraction Rule API Example](https://github.com/voltaire321/sumologictoolbox/blob/master/screenshots/sumotoolbox_FER_example.png "Content API")
+![Field Extraction Rule API Example](https://github.com/SumoLogic/sumologictoolbox/blob/master/screenshots/sumotoolbox_FER_example.png "Content API")
 
-![Scheduled View API Example](https://github.com/voltaire321/sumologictoolbox/blob/master/screenshots/sumotoolbox_SV_example.png "Content API")
+![Scheduled View API Example](https://https://github.com/SumoLogic/sumologictoolbox/blob/master/screenshots/sumotoolbox_SV_example.png "Content API")
 
 Known Issues:
 =============

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,8 @@ Sumotoolbox
  it easier to perform common API tasks such as copying sources and generating CSV files from
  searches.
 
+This version contains critical updates to the 'collectors' and 'source updates' tab. It is highly recommended that you upgrade to this version or later (0.9.1)
+
 Recommended Method of Getting and Running Sumotoolbox, download the binaries
 ============================================================================
 

--- a/readme.md
+++ b/readme.md
@@ -466,9 +466,9 @@ Screen Shots:
 
 ![Collector Source Copy](https://github.com/SumoLogic/sumologictoolbox/blob/master/screenshots/sumotoolbox_collector_example.png "Source Copy")
 
-![Search API Example](https://github.com/SumoLogic/sumologictoolbox/sumologictoolbox/blob/master/screenshots/sumotoolbox_search_example.png "Search API")
+![Search API Example](https://github.com/SumoLogic/sumologictoolbox/blob/master/screenshots/sumotoolbox_search_example.png "Search API")
 
-![Content API Example](https://github.com/SumoLogic/sumologictoolbox/sumologictoolbox/blob/master/screenshots/sumotoolbox_content_example.png "Content API")
+![Content API Example](https://github.com/SumoLogic/sumologictoolbox/blob/master/screenshots/sumotoolbox_content_example.png "Content API")
 
 ![Field Extraction Rule API Example](https://github.com/SumoLogic/sumologictoolbox/blob/master/screenshots/sumotoolbox_FER_example.png "Content API")
 


### PR DESCRIPTION
Hi @voltaire321 I hope you find this valuable enough to merge.

1. When contents being copied is an active scheduled search associated with a Connection/WebHook this would be correctly set if the connection exists in the destination org or it will be created and specified otherwise.
2. Any contented will be copied it will include their permissions, i.e. sharing instruction copied over, part of that using the API/v1/account/contract to get the org-id
3. Copying missing permitted users/roles to the destination on the fly
4. While the tool is copying the permission it needs to match contents, so any found to be missing on the destination it will be logged to the logger with enough details to be mitigated or reported
5. You may want to add and give the UI options on what action to take when permitted users/roles are not found on the destination, whether to copy them on the fly or log the details, raise an exception and abort copying the content in question.

Finally thank you for such incredible work which makes our job and our customers and users more comfortable.

Thanks,
Ammar